### PR TITLE
Fixing erasing issue in the second tee command

### DIFF
--- a/set_target_aliases.sh
+++ b/set_target_aliases.sh
@@ -5,7 +5,7 @@ targets_ip=".targets_ip"
 mkdir -p ~/.config;
 
 sed "/^#/d" $targets_ip | sed "/not found/d" | awk '{print "alias ssh"$1"=\"ssh "$3"@"$4"\""}' | tee ~/.config/targets_alias
-sed "/^#/d" $targets_ip | sed "/not found/d" | awk '{print "alias ssh"$1"x=\"ssh -X "$3"@"$4"\""}' | tee ~/.config/targets_alias
+sed "/^#/d" $targets_ip | sed "/not found/d" | awk '{print "alias ssh"$1"x=\"ssh -X "$3"@"$4"\""}' | tee -a ~/.config/targets_alias
 
 
 echo ""


### PR DESCRIPTION
Hi dear Sebastien,

I found a small mistake in your very useful tool, BTW I thank you sooo much for sharing this to the world.
As I was using your wonderfull scripts, I saw that the tee command didn't append the ssh -X aliases but was rather overwritting the file, thereby erasing the previous lines of aliases. I managed to fix the problem by simply adding "-a" options. 
I hope you find my fix usefull.

Best regards